### PR TITLE
Add initial batch on annotations for entity configs

### DIFF
--- a/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeCreate.java
+++ b/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeCreate.java
@@ -1,0 +1,12 @@
+package org.cobbzilla.wizard.model.entityconfig.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+public @interface ECTypeCreate {
+    String method() default "";
+    String uri();
+}

--- a/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeDelete.java
+++ b/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeDelete.java
@@ -1,0 +1,12 @@
+package org.cobbzilla.wizard.model.entityconfig.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+public @interface ECTypeDelete {
+    String method() default "";
+    String uri();
+}

--- a/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeList.java
+++ b/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeList.java
@@ -1,0 +1,12 @@
+package org.cobbzilla.wizard.model.entityconfig.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+public @interface ECTypeList {
+    String[] fields() default {};
+    String uri();
+}

--- a/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeName.java
+++ b/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeName.java
@@ -1,0 +1,13 @@
+package org.cobbzilla.wizard.model.entityconfig.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+public @interface ECTypeName {
+    String name();
+    String displayName() default "";
+    String pluralDisplayName() default "";
+}

--- a/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeSearch.java
+++ b/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeSearch.java
@@ -1,0 +1,13 @@
+package org.cobbzilla.wizard.model.entityconfig.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+public @interface ECTypeSearch {
+    String[] fields() default {};
+    String method() default "";
+    String uri();
+}

--- a/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeUpdate.java
+++ b/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECTypeUpdate.java
@@ -1,0 +1,12 @@
+package org.cobbzilla.wizard.model.entityconfig.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
+public @interface ECTypeUpdate {
+    String method() default "";
+    String uri();
+}

--- a/wizard-server/src/main/java/org/cobbzilla/wizard/resources/AbstractEntityConfigsResource.java
+++ b/wizard-server/src/main/java/org/cobbzilla/wizard/resources/AbstractEntityConfigsResource.java
@@ -75,8 +75,9 @@ public abstract class AbstractEntityConfigsResource {
                 try {
                     final EntityConfig localConfig = fromJson(localFile, EntityConfig.class, FULL_MAPPER_ALLOW_COMMENTS);
                     if (localConfig != null) {
+                        localConfig.setClassName(config.getClassName());
                         setNames(localConfig);
-                        return ok(localConfig);
+                        return ok(localConfig.updateWithAnnotations());
                     }
                 } catch (Exception e) {
                     log.warn("getConfig("+name+"): debug enabled and local config exists ("+abs(localFile)+"), but error loading: "+e);
@@ -136,7 +137,7 @@ public abstract class AbstractEntityConfigsResource {
         try {
             final EntityConfig entityConfig = fromJson(in, EntityConfig.class, FULL_MAPPER_ALLOW_COMMENTS);
             entityConfig.setClassName(clazz.getName());
-            return entityConfig;
+            return entityConfig.updateWithAnnotations(clazz);
         } catch (Exception e) {
             return die("getEntityConfig("+clazz.getName()+"): "+e, e);
         }


### PR DESCRIPTION
This is the first part of the refactoring. The one that follows (after this one is merged, tested and used for a while) should include the other stuff which currently is not supported by these newly added annotations.