### PR TITLE
Better way to key entity config field ordering

### DIFF
--- a/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/EntityConfig.java
+++ b/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/EntityConfig.java
@@ -292,10 +292,11 @@ public class EntityConfig {
         if (!empty(annotation.list())) {
             // initialization of fieldNames according to the fields map (if set)
             if (fieldNames == null) fieldNames = getFieldNames();
-            for (int i = annotation.list().length - 1; i >= 0; i--){
-                String fieldName = annotation.list()[i];
-                if (!fieldNames.contains(fieldName)) fieldNames.add(0, fieldName);
-            }
+            List<String> annotationFieldNames = Arrays.asList(annotation.list());
+            // remove duplicates if any ...
+            fieldNames.removeAll(annotationFieldNames);
+            // ... then add the set list in front of other fields (possibly set in JSON)
+            fieldNames.addAll(0, annotationFieldNames);
 
             if (fields == null) fields = new HashMap<>(fieldNames.size());
             ReflectionUtils.doWithFields(


### PR DESCRIPTION
@cobbzilla please review

This new way of preserving the fields order will preserve the order from the annotation for sure (even if the separate fields themselves are defined in JSON only).
The fields from JSON which are not stated in this annotation list will still be shown in the resulting entity config, but they will still be at the end of the list (which is ok). For this, it is advised to put the complete list in the annotation.