### PR TITLE
Add support to override EC field reference deeper in children tree

### DIFF
--- a/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECFieldReferenceOverwrite.java
+++ b/wizard-common/src/main/java/org/cobbzilla/wizard/model/entityconfig/annotations/ECFieldReferenceOverwrite.java
@@ -7,6 +7,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
 public @interface ECFieldReferenceOverwrite {
-    String fieldName();
+    String fieldPath(); // field's path through the children tree (dot separated), or annotated class field's name.
     ECFieldReference fieldDef();
 }


### PR DESCRIPTION
@cobbzilla please review.
Note that there will be a pull request within qbis repo that must go right after this one - the change here (renaming the annotation property method initially created just a few pull requests ago) is not backward compatible.